### PR TITLE
fix: remove custom paddings from secondary bar items

### DIFF
--- a/views/components/SecondaryBarItem.tsx
+++ b/views/components/SecondaryBarItem.tsx
@@ -46,7 +46,6 @@ const CustomAccordionItem = styled(AccordionItem)`
 	background-color: ${({ theme, dragging }): string =>
 		dragging ? getColor('gray5', theme) : 'inherit'};
 	height: 40px;
-	padding: 8px 8px 8px 16px;
 `;
 
 export type BadgeType = 'read' | 'unread' | undefined;


### PR DESCRIPTION
Following Zextras/carbonio-design-system#52 changes, remove custom paddings in favor of DS ones

refs: FILES-234