### PR TITLE
refactor: change imports of lodash from default to named

### DIFF
--- a/apollo/cacheUtils.ts
+++ b/apollo/cacheUtils.ts
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { ApolloCache, NormalizedCacheObject } from '@apollo/client';
-import filter from 'lodash/filter';
-import findIndex from 'lodash/findIndex';
-import size from 'lodash/size';
+import { filter, findIndex, size } from 'lodash';
 
 import CHILD from '../graphql/fragments/child.graphql';
 import GET_CHILDREN from '../graphql/queries/getChildren.graphql';

--- a/apollo/typePolicies/fieldPolicies/getNode.ts
+++ b/apollo/typePolicies/fieldPolicies/getNode.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { FieldFunctionOptions, FieldPolicy, Reference } from '@apollo/client';
-import find from 'lodash/find';
+import { find } from 'lodash';
 
 import introspection from '../../../types/graphql/possible-types';
 import { GetNodeQueryVariables, QueryGetNodeArgs } from '../../../types/graphql/types';

--- a/apollo/typePolicies/fieldPolicies/getUploadItems.ts
+++ b/apollo/typePolicies/fieldPolicies/getUploadItems.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { FieldFunctionOptions, FieldPolicy } from '@apollo/client';
-import filter from 'lodash/filter';
+import { filter } from 'lodash';
 
 import { UploadItem } from '../../../types/graphql/client-types';
 import { uploadVar } from '../../uploadVar';

--- a/apollo/typePolicies/utils.ts
+++ b/apollo/typePolicies/utils.ts
@@ -5,7 +5,7 @@
  */
 
 import { FieldFunctionOptions, Reference } from '@apollo/client';
-import keyBy from 'lodash/keyBy';
+import { keyBy } from 'lodash';
 
 import { NodesListCachedObject } from '../../types/apollo';
 

--- a/hooks/graphql/mutations/useCopyNodesMutation.ts
+++ b/hooks/graphql/mutations/useCopyNodesMutation.ts
@@ -8,8 +8,7 @@ import { useCallback } from 'react';
 
 import { FetchResult, useMutation, useReactiveVar } from '@apollo/client';
 import { useSnackbar } from '@zextras/carbonio-design-system';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { forEach, map } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 

--- a/hooks/graphql/mutations/useDeleteCollaborationLinksMutation.ts
+++ b/hooks/graphql/mutations/useDeleteCollaborationLinksMutation.ts
@@ -8,8 +8,7 @@
 import { useCallback } from 'react';
 
 import { FetchResult, useMutation } from '@apollo/client';
-import filter from 'lodash/filter';
-import includes from 'lodash/includes';
+import { filter, includes } from 'lodash';
 
 import COLLABORATION_LINK from '../../../graphql/fragments/collaborationLink.graphql';
 import DELETE_COLLABORATION_LINKS from '../../../graphql/mutations/deleteCollaborationLinks.graphql';

--- a/hooks/graphql/mutations/useDeleteLinksMutation.ts
+++ b/hooks/graphql/mutations/useDeleteLinksMutation.ts
@@ -8,8 +8,7 @@
 import { useCallback } from 'react';
 
 import { FetchResult, useMutation } from '@apollo/client';
-import filter from 'lodash/filter';
-import includes from 'lodash/includes';
+import { filter, includes } from 'lodash';
 
 import LINK from '../../../graphql/fragments/link.graphql';
 import DELETE_LINKS from '../../../graphql/mutations/deleteLinks.graphql';

--- a/hooks/graphql/mutations/useDeleteNodesMutation.ts
+++ b/hooks/graphql/mutations/useDeleteNodesMutation.ts
@@ -8,8 +8,7 @@ import { useCallback } from 'react';
 
 import { FetchResult, useMutation } from '@apollo/client';
 import { useSnackbar } from '@zextras/carbonio-design-system';
-import map from 'lodash/map';
-import some from 'lodash/some';
+import { map, some } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveNode } from '../../../../hooks/useActiveNode';

--- a/hooks/graphql/mutations/useDeleteShareMutation.ts
+++ b/hooks/graphql/mutations/useDeleteShareMutation.ts
@@ -8,8 +8,7 @@ import { useCallback } from 'react';
 
 import { FetchResult, useMutation } from '@apollo/client';
 import { useSnackbar } from '@zextras/carbonio-design-system';
-import filter from 'lodash/filter';
-import some from 'lodash/some';
+import { filter, some } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 

--- a/hooks/graphql/mutations/useDeleteVersionsMutation.ts
+++ b/hooks/graphql/mutations/useDeleteVersionsMutation.ts
@@ -7,8 +7,7 @@
 import { useCallback } from 'react';
 
 import { FetchResult, useMutation } from '@apollo/client';
-import filter from 'lodash/filter';
-import includes from 'lodash/includes';
+import { filter, includes } from 'lodash';
 
 import DELETE_VERSIONS from '../../../graphql/mutations/deleteVersions.graphql';
 import GET_VERSIONS from '../../../graphql/queries/getVersions.graphql';

--- a/hooks/graphql/mutations/useFlagNodesMutation.ts
+++ b/hooks/graphql/mutations/useFlagNodesMutation.ts
@@ -8,10 +8,7 @@ import { useCallback } from 'react';
 
 import { FetchResult, useMutation } from '@apollo/client';
 import { useSnackbar } from '@zextras/carbonio-design-system';
-import find from 'lodash/find';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
-import some from 'lodash/some';
+import { forEach, map, find, some } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 

--- a/hooks/graphql/mutations/useKeepVersionsMutation.ts
+++ b/hooks/graphql/mutations/useKeepVersionsMutation.ts
@@ -7,8 +7,7 @@
 import { useCallback } from 'react';
 
 import { FetchResult, useMutation } from '@apollo/client';
-import includes from 'lodash/includes';
-import map from 'lodash/map';
+import { map, includes } from 'lodash';
 
 import KEEP_VERSIONS from '../../../graphql/mutations/keepVersions.graphql';
 import GET_VERSIONS from '../../../graphql/queries/getVersions.graphql';

--- a/hooks/graphql/mutations/useMoveNodesMutation.ts
+++ b/hooks/graphql/mutations/useMoveNodesMutation.ts
@@ -8,10 +8,7 @@ import { useCallback } from 'react';
 
 import { FetchResult, useMutation } from '@apollo/client';
 import { useSnackbar } from '@zextras/carbonio-design-system';
-import find from 'lodash/find';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
-import some from 'lodash/some';
+import { forEach, map, find, some } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 

--- a/hooks/graphql/mutations/useRestoreNodesMutation.ts
+++ b/hooks/graphql/mutations/useRestoreNodesMutation.ts
@@ -8,12 +8,7 @@ import { useCallback } from 'react';
 
 import { FetchResult, useMutation } from '@apollo/client';
 import { useSnackbar } from '@zextras/carbonio-design-system';
-import filter from 'lodash/filter';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
-import reduce from 'lodash/reduce';
-import size from 'lodash/size';
-import some from 'lodash/some';
+import { forEach, map, filter, reduce, size, some } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 

--- a/hooks/graphql/mutations/useTrashNodesMutation.ts
+++ b/hooks/graphql/mutations/useTrashNodesMutation.ts
@@ -8,11 +8,7 @@ import { useCallback } from 'react';
 
 import { FetchResult, useMutation } from '@apollo/client';
 import { useSnackbar } from '@zextras/carbonio-design-system';
-import find from 'lodash/find';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
-import partition from 'lodash/partition';
-import some from 'lodash/some';
+import { forEach, map, find, partition, some } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 

--- a/hooks/graphql/mutations/useUpdateShareMutation.ts
+++ b/hooks/graphql/mutations/useUpdateShareMutation.ts
@@ -7,7 +7,7 @@
 import { useCallback } from 'react';
 
 import { ApolloError, FetchResult, useMutation } from '@apollo/client';
-import reduce from 'lodash/reduce';
+import { reduce } from 'lodash';
 
 import SHARE_TARGET from '../../../graphql/fragments/shareTarget.graphql';
 import UPDATE_SHARE from '../../../graphql/mutations/updateShare.graphql';

--- a/hooks/graphql/queries/useFindNodesQuery.ts
+++ b/hooks/graphql/queries/useFindNodesQuery.ts
@@ -7,7 +7,7 @@
 import { useCallback } from 'react';
 
 import { ApolloQueryResult, QueryResult, useQuery } from '@apollo/client';
-import isEqual from 'lodash/isEqual';
+import { isEqual } from 'lodash';
 
 import { NODES_LOAD_LIMIT } from '../../../constants';
 import FIND_NODES from '../../../graphql/queries/findNodes.graphql';

--- a/hooks/graphql/queries/useGetChildrenQuery.ts
+++ b/hooks/graphql/queries/useGetChildrenQuery.ts
@@ -7,7 +7,7 @@
 import { useCallback, useMemo } from 'react';
 
 import { QueryResult, useQuery, useReactiveVar } from '@apollo/client';
-import isEqual from 'lodash/isEqual';
+import { isEqual } from 'lodash';
 
 import { nodeSortVar } from '../../../apollo/nodeSortVar';
 import { NODES_LOAD_LIMIT } from '../../../constants';

--- a/hooks/graphql/queries/useGetConfigsQuery.ts
+++ b/hooks/graphql/queries/useGetConfigsQuery.ts
@@ -6,7 +6,7 @@
 import { useMemo } from 'react';
 
 import { useQuery } from '@apollo/client';
-import reduce from 'lodash/reduce';
+import { reduce } from 'lodash';
 
 import GET_CONFIGS from '../../../graphql/queries/getConfigs.graphql';
 import { Config, GetConfigsQuery, GetConfigsQueryVariables } from '../../../types/graphql/types';

--- a/hooks/graphql/useUpdateFilterContent.ts
+++ b/hooks/graphql/useUpdateFilterContent.ts
@@ -7,8 +7,7 @@
 import { useCallback } from 'react';
 
 import { ApolloClient, NormalizedCacheObject, useApolloClient } from '@apollo/client';
-import filter from 'lodash/filter';
-import size from 'lodash/size';
+import { filter, size } from 'lodash';
 
 import { FindNodesCachedObject } from '../../types/apollo';
 

--- a/hooks/graphql/useUpdateFolderContent.test.ts
+++ b/hooks/graphql/useUpdateFolderContent.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import find from 'lodash/find';
+import { find } from 'lodash';
 
 import { NODES_LOAD_LIMIT, NODES_SORT_DEFAULT } from '../../constants';
 import GET_CHILDREN from '../../graphql/queries/getChildren.graphql';

--- a/hooks/modals/useNodesSelectionModal.tsx
+++ b/hooks/modals/useNodesSelectionModal.tsx
@@ -8,7 +8,7 @@ import React, { useCallback } from 'react';
 
 import { ApolloProvider, ReactiveVar } from '@apollo/client';
 import { useModal } from '@zextras/carbonio-design-system';
-import size from 'lodash/size';
+import { size } from 'lodash';
 
 import buildClient from '../../apollo';
 import { DestinationVar, destinationVar } from '../../apollo/destinationVar';

--- a/hooks/useBreadcrumb.ts
+++ b/hooks/useBreadcrumb.ts
@@ -7,7 +7,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { ApolloError, useApolloClient, useQuery } from '@apollo/client';
-import size from 'lodash/size';
+import { size } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import GET_PARENT from '../graphql/queries/getParent.graphql';

--- a/hooks/useDroppableCrumbs.ts
+++ b/hooks/useDroppableCrumbs.ts
@@ -8,10 +8,7 @@ import React, { DragEventHandler, useCallback, useEffect, useMemo, useRef } from
 
 import { gql, useApolloClient } from '@apollo/client';
 import { BreadcrumbsProps, getColor, useSnackbar } from '@zextras/carbonio-design-system';
-import forEach from 'lodash/forEach';
-import isEmpty from 'lodash/isEmpty';
-import map from 'lodash/map';
-import uniq from 'lodash/uniq';
+import { forEach, isEmpty, map, uniq } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { DefaultTheme, useTheme } from 'styled-components';
 

--- a/hooks/useSelection.ts
+++ b/hooks/useSelection.ts
@@ -7,12 +7,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useReactiveVar } from '@apollo/client';
-import filter from 'lodash/filter';
-import find from 'lodash/find';
-import includes from 'lodash/includes';
-import isEqual from 'lodash/isEqual';
-import map from 'lodash/map';
-import reduce from 'lodash/reduce';
+import { map, find, filter, includes, isEqual, reduce } from 'lodash';
 
 import { selectionModeVar } from '../apollo/selectionVar';
 import { PickIdNodeType } from '../types/common';

--- a/hooks/useUpload.ts
+++ b/hooks/useUpload.ts
@@ -6,13 +6,7 @@
 
 import { useCallback, useMemo } from 'react';
 
-import filter from 'lodash/filter';
-import forEach from 'lodash/forEach';
-import includes from 'lodash/includes';
-import map from 'lodash/map';
-import noop from 'lodash/noop';
-import partition from 'lodash/partition';
-import reduce from 'lodash/reduce';
+import { forEach, map, filter, includes, reduce, noop, partition } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 
 import buildClient from '../apollo';

--- a/hooks/useUploadActions.ts
+++ b/hooks/useUploadActions.ts
@@ -6,7 +6,7 @@
 import { useCallback, useMemo } from 'react';
 
 import { Action as DSAction } from '@zextras/carbonio-design-system';
-import map from 'lodash/map';
+import { map } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { useNavigation } from '../../hooks/useNavigation';

--- a/mocks/handleCopyNodesRequest.ts
+++ b/mocks/handleCopyNodesRequest.ts
@@ -5,7 +5,7 @@
  */
 
 import { faker } from '@faker-js/faker';
-import forEach from 'lodash/forEach';
+import { forEach } from 'lodash';
 import { GraphQLContext, GraphQLRequest, ResponseResolver } from 'msw';
 
 import buildClient from '../apollo';

--- a/mocks/handleFindNodesRequest.ts
+++ b/mocks/handleFindNodesRequest.ts
@@ -5,7 +5,7 @@
  */
 
 import { faker } from '@faker-js/faker';
-import take from 'lodash/take';
+import { take } from 'lodash';
 import { GraphQLContext, GraphQLRequest, ResponseResolver, ResponseTransformer } from 'msw';
 
 import { ROOTS } from '../constants';

--- a/mocks/handleGetChildRequest.ts
+++ b/mocks/handleGetChildRequest.ts
@@ -5,7 +5,7 @@
  */
 
 import { faker } from '@faker-js/faker';
-import take from 'lodash/take';
+import { take } from 'lodash';
 import { GraphQLContext, GraphQLRequest, ResponseResolver } from 'msw';
 
 import { ROOTS } from '../constants';

--- a/mocks/handleGetChildrenRequest.ts
+++ b/mocks/handleGetChildrenRequest.ts
@@ -5,8 +5,7 @@
  */
 
 import { faker } from '@faker-js/faker';
-import forEach from 'lodash/forEach';
-import take from 'lodash/take';
+import { forEach, take } from 'lodash';
 import { GraphQLContext, GraphQLRequest, ResponseResolver } from 'msw';
 
 import { ROOTS } from '../constants';

--- a/mocks/handleGetNodeRequest.ts
+++ b/mocks/handleGetNodeRequest.ts
@@ -5,8 +5,7 @@
  */
 
 import { faker } from '@faker-js/faker';
-import forEach from 'lodash/forEach';
-import take from 'lodash/take';
+import { forEach, take } from 'lodash';
 import { GraphQLContext, GraphQLRequest, ResponseResolver } from 'msw';
 
 import { ROOTS } from '../constants';

--- a/mocks/handleGetSharesRequest.ts
+++ b/mocks/handleGetSharesRequest.ts
@@ -5,7 +5,7 @@
  */
 
 import { faker } from '@faker-js/faker';
-import take from 'lodash/take';
+import { take } from 'lodash';
 import { GraphQLContext, GraphQLRequest, ResponseResolver } from 'msw';
 
 import { ROOTS } from '../constants';

--- a/mocks/handleGetVersionsRequest.ts
+++ b/mocks/handleGetVersionsRequest.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import map from 'lodash/map';
+import { map } from 'lodash';
 import { GraphQLContext, GraphQLRequest, ResponseResolver } from 'msw';
 
 import { GetVersionsQuery, GetVersionsQueryVariables } from '../types/graphql/types';

--- a/mocks/handleMoveNodesRequest.ts
+++ b/mocks/handleMoveNodesRequest.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import forEach from 'lodash/forEach';
+import { forEach } from 'lodash';
 import { GraphQLContext, GraphQLRequest, ResponseResolver } from 'msw';
 
 import buildClient from '../apollo';

--- a/mocks/handleRestoreNodesRequest.ts
+++ b/mocks/handleRestoreNodesRequest.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import map from 'lodash/map';
+import { map } from 'lodash';
 import { GraphQLContext, GraphQLRequest, ResponseResolver } from 'msw';
 
 import { ROOTS } from '../constants';

--- a/mocks/mockUtils.ts
+++ b/mocks/mockUtils.ts
@@ -5,10 +5,7 @@
  */
 
 import { faker } from '@faker-js/faker';
-import filter from 'lodash/filter';
-import find from 'lodash/find';
-import map from 'lodash/map';
-import some from 'lodash/some';
+import { map, find, filter, some } from 'lodash';
 
 import { LOGGED_USER } from '../../mocks/constants';
 import { CONFIGS, NODES_LOAD_LIMIT, NODES_SORT_DEFAULT, ROOTS } from '../constants';

--- a/utils/ActionsFactory.ts
+++ b/utils/ActionsFactory.ts
@@ -5,14 +5,7 @@
  */
 
 import type { Action as DSAction } from '@zextras/carbonio-design-system';
-import every from 'lodash/every';
-import find from 'lodash/find';
-import forEach from 'lodash/forEach';
-import includes from 'lodash/includes';
-import isBoolean from 'lodash/isBoolean';
-import reduce from 'lodash/reduce';
-import size from 'lodash/size';
-import some from 'lodash/some';
+import { forEach, find, includes, reduce, size, some, every, isBoolean } from 'lodash';
 
 import { ACTIONS_TO_REMOVE_DUE_TO_PRODUCT_CONTEXT } from '../../constants';
 import { ROOTS } from '../constants';

--- a/utils/testUtils.tsx
+++ b/utils/testUtils.tsx
@@ -30,10 +30,7 @@ import { PreviewManager, PreviewsManagerContext } from '@zextras/carbonio-ui-pre
 import { PreviewManagerContextType } from '@zextras/carbonio-ui-preview/lib/preview/PreviewManager';
 import { EventEmitter } from 'events';
 import { GraphQLError } from 'graphql';
-import filter from 'lodash/filter';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
-import reduce from 'lodash/reduce';
+import { forEach, map, filter, reduce } from 'lodash';
 import { I18nextProvider } from 'react-i18next';
 import { MemoryRouter } from 'react-router-dom';
 

--- a/utils/uploadUtils.ts
+++ b/utils/uploadUtils.ts
@@ -8,12 +8,7 @@
 // it might be a file without extension and with a size of 0 or exactly N x 4096B.
 // https://stackoverflow.com/a/25095250/17280436
 import { ApolloClient, ApolloQueryResult, NormalizedCacheObject } from '@apollo/client';
-import filter from 'lodash/filter';
-import find from 'lodash/find';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
-import pull from 'lodash/pull';
-import reduce from 'lodash/reduce';
+import { forEach, map, find, filter, reduce, pull } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 
 import { UploadFunctions, uploadFunctionsVar, UploadRecord, uploadVar } from '../apollo/uploadVar';

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -8,17 +8,19 @@ import React from 'react';
 
 import { ApolloError } from '@apollo/client';
 import { Location } from 'history';
-import { chain } from 'lodash';
-import debounce from 'lodash/debounce';
-import findIndex from 'lodash/findIndex';
-import first from 'lodash/first';
-import forEach from 'lodash/forEach';
-import includes from 'lodash/includes';
-import map from 'lodash/map';
-import reduce from 'lodash/reduce';
-import size from 'lodash/size';
-import toLower from 'lodash/toLower';
-import trim from 'lodash/trim';
+import {
+	chain,
+	forEach,
+	map,
+	includes,
+	reduce,
+	size,
+	debounce,
+	findIndex,
+	first,
+	toLower,
+	trim
+} from 'lodash';
 import moment, { Moment } from 'moment-timezone';
 import { TFunction } from 'react-i18next';
 

--- a/views/FileView.tsx
+++ b/views/FileView.tsx
@@ -7,7 +7,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { Container, Responsive, Snackbar } from '@zextras/carbonio-design-system';
-import noop from 'lodash/noop';
+import { noop } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { ACTION_IDS, ACTION_TYPES } from '../../constants';

--- a/views/FilterView.copy.test.tsx
+++ b/views/FilterView.copy.test.tsx
@@ -6,8 +6,7 @@
 import React from 'react';
 
 import { fireEvent, screen, within } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { forEach, map } from 'lodash';
 import { Route } from 'react-router-dom';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';

--- a/views/FilterView.deletePermanently.test.tsx
+++ b/views/FilterView.deletePermanently.test.tsx
@@ -6,9 +6,7 @@
 import React from 'react';
 
 import { act, fireEvent, screen, waitForElementToBeRemoved, within } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import last from 'lodash/last';
-import map from 'lodash/map';
+import { forEach, map, last } from 'lodash';
 import { Route } from 'react-router-dom';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';

--- a/views/FilterView.displayer.test.tsx
+++ b/views/FilterView.displayer.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 
 import { fireEvent, screen, waitForElementToBeRemoved, within } from '@testing-library/react';
-import map from 'lodash/map';
+import { map } from 'lodash';
 import { graphql } from 'msw';
 import { Route } from 'react-router-dom';
 

--- a/views/FilterView.dragAndDrop.test.tsx
+++ b/views/FilterView.dragAndDrop.test.tsx
@@ -6,8 +6,7 @@
 import React from 'react';
 
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { forEach, map } from 'lodash';
 import { graphql } from 'msw';
 import { Route } from 'react-router-dom';
 

--- a/views/FilterView.flag.test.tsx
+++ b/views/FilterView.flag.test.tsx
@@ -6,9 +6,7 @@
 import React from 'react';
 
 import { fireEvent, screen, waitForElementToBeRemoved } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import last from 'lodash/last';
-import map from 'lodash/map';
+import { forEach, map, last } from 'lodash';
 import { Route } from 'react-router-dom';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';

--- a/views/FilterView.markForDeletion.test.tsx
+++ b/views/FilterView.markForDeletion.test.tsx
@@ -6,9 +6,7 @@
 import React from 'react';
 
 import { fireEvent, screen, waitForElementToBeRemoved, within } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import last from 'lodash/last';
-import map from 'lodash/map';
+import { forEach, map, last } from 'lodash';
 import { Route } from 'react-router-dom';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';

--- a/views/FilterView.move.test.tsx
+++ b/views/FilterView.move.test.tsx
@@ -6,8 +6,7 @@
 import React from 'react';
 
 import { fireEvent, screen, within } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { forEach, map } from 'lodash';
 import { Route } from 'react-router-dom';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';

--- a/views/FilterView.rename.test.tsx
+++ b/views/FilterView.rename.test.tsx
@@ -14,9 +14,7 @@ import {
 	waitForElementToBeRemoved,
 	within
 } from '@testing-library/react';
-import find from 'lodash/find';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { forEach, map, find } from 'lodash';
 import { Route } from 'react-router-dom';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';

--- a/views/FilterView.restore.test.tsx
+++ b/views/FilterView.restore.test.tsx
@@ -6,9 +6,7 @@
 import React from 'react';
 
 import { fireEvent, screen, waitForElementToBeRemoved, within } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import last from 'lodash/last';
-import map from 'lodash/map';
+import { forEach, map, last } from 'lodash';
 import { Route } from 'react-router-dom';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';

--- a/views/FilterView.sharedByMe.test.tsx
+++ b/views/FilterView.sharedByMe.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 
 import { screen, within } from '@testing-library/react';
-import find from 'lodash/find';
+import { find } from 'lodash';
 import { graphql } from 'msw';
 import { Route } from 'react-router-dom';
 

--- a/views/FilterView.test.tsx
+++ b/views/FilterView.test.tsx
@@ -7,8 +7,7 @@
 import React from 'react';
 
 import { screen, waitFor, waitForElementToBeRemoved, within } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { forEach, map } from 'lodash';
 import { graphql } from 'msw';
 import { Link, Route, Switch } from 'react-router-dom';
 

--- a/views/FilterView.trash.test.tsx
+++ b/views/FilterView.trash.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
-import forEach from 'lodash/forEach';
+import { forEach } from 'lodash';
 import { graphql } from 'msw';
 import { Route } from 'react-router-dom';
 

--- a/views/FilterView.tsx
+++ b/views/FilterView.tsx
@@ -8,8 +8,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useReactiveVar } from '@apollo/client';
 import { Container, Responsive, Snackbar } from '@zextras/carbonio-design-system';
-import filter from 'lodash/filter';
-import noop from 'lodash/noop';
+import { filter, noop } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router-dom';
 

--- a/views/FolderView.copy.test.tsx
+++ b/views/FolderView.copy.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import { faker } from '@faker-js/faker';
 import { act, fireEvent, screen, within } from '@testing-library/react';
-import map from 'lodash/map';
+import { map } from 'lodash';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import { ACTION_REGEXP, ICON_REGEXP, SELECTORS } from '../constants/test';

--- a/views/FolderView.createDocsFile.test.tsx
+++ b/views/FolderView.createDocsFile.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import { screen, waitForElementToBeRemoved, within } from '@testing-library/react';
 import { DropdownItem } from '@zextras/carbonio-design-system';
-import find from 'lodash/find';
+import { find } from 'lodash';
 import { graphql, rest } from 'msw';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';

--- a/views/FolderView.createFolder.test.tsx
+++ b/views/FolderView.createFolder.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { ApolloError } from '@apollo/client';
 import { act, screen, waitForElementToBeRemoved, within } from '@testing-library/react';
 import { DropdownItem } from '@zextras/carbonio-design-system';
-import find from 'lodash/find';
+import { find } from 'lodash';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import { NODES_LOAD_LIMIT, NODES_SORT_DEFAULT } from '../constants';

--- a/views/FolderView.dragAndDrop.test.tsx
+++ b/views/FolderView.dragAndDrop.test.tsx
@@ -14,9 +14,7 @@ import {
 	waitForElementToBeRemoved,
 	within
 } from '@testing-library/react';
-import find from 'lodash/find';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { forEach, map, find } from 'lodash';
 import { graphql } from 'msw';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';

--- a/views/FolderView.flag.test.tsx
+++ b/views/FolderView.flag.test.tsx
@@ -7,8 +7,7 @@
 import React from 'react';
 
 import { fireEvent, screen, waitForElementToBeRemoved, within } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { forEach, map } from 'lodash';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import { ACTION_REGEXP, ICON_REGEXP, SELECTORS } from '../constants/test';

--- a/views/FolderView.getChildren.test.tsx
+++ b/views/FolderView.getChildren.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import { ApolloError } from '@apollo/client';
 import { screen, waitFor, waitForElementToBeRemoved, within } from '@testing-library/react';
-import forEach from 'lodash/forEach';
+import { forEach } from 'lodash';
 import { graphql } from 'msw';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';

--- a/views/FolderView.markForDeletion.test.tsx
+++ b/views/FolderView.markForDeletion.test.tsx
@@ -7,8 +7,7 @@
 import React from 'react';
 
 import { fireEvent, screen, waitForElementToBeRemoved } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { forEach, map } from 'lodash';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import { NODES_LOAD_LIMIT } from '../constants';

--- a/views/FolderView.move.test.tsx
+++ b/views/FolderView.move.test.tsx
@@ -13,8 +13,7 @@ import {
 	waitForElementToBeRemoved,
 	within
 } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { forEach, map } from 'lodash';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import { NODES_LOAD_LIMIT } from '../constants';

--- a/views/FolderView.rename.test.tsx
+++ b/views/FolderView.rename.test.tsx
@@ -7,10 +7,7 @@
 import React from 'react';
 
 import { fireEvent, screen, waitForElementToBeRemoved, within } from '@testing-library/react';
-import findIndex from 'lodash/findIndex';
-import forEach from 'lodash/forEach';
-import last from 'lodash/last';
-import map from 'lodash/map';
+import { forEach, map, findIndex, last } from 'lodash';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import { NODES_LOAD_LIMIT, NODES_SORT_DEFAULT } from '../constants';

--- a/views/FolderView.selectionMode.test.tsx
+++ b/views/FolderView.selectionMode.test.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { screen } from '@testing-library/react';
-import forEach from 'lodash/forEach';
+import { forEach } from 'lodash';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import { NODES_LOAD_LIMIT } from '../constants';

--- a/views/FolderView.test.tsx
+++ b/views/FolderView.test.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { fireEvent, screen, within } from '@testing-library/react';
-import map from 'lodash/map';
+import { map } from 'lodash';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import GET_CHILD from '../graphql/queries/getChild.graphql';

--- a/views/FolderView.tsx
+++ b/views/FolderView.tsx
@@ -8,9 +8,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Container, Responsive } from '@zextras/carbonio-design-system';
 import { Action } from '@zextras/carbonio-shell-ui';
-import filter from 'lodash/filter';
-import last from 'lodash/last';
-import map from 'lodash/map';
+import { map, filter, last } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 

--- a/views/InteractiveBreadcrumbs.tsx
+++ b/views/InteractiveBreadcrumbs.tsx
@@ -7,7 +7,7 @@
 import React, { useMemo } from 'react';
 
 import { BreadcrumbsProps, getColor } from '@zextras/carbonio-design-system';
-import map from 'lodash/map';
+import { map } from 'lodash';
 import styled from 'styled-components';
 
 import { Breadcrumbs } from '../design_system_fork/Breadcrumbs';

--- a/views/SearchView.test.tsx
+++ b/views/SearchView.test.tsx
@@ -7,8 +7,7 @@
 import React from 'react';
 
 import { fireEvent, screen, within } from '@testing-library/react';
-import find from 'lodash/find';
-import map from 'lodash/map';
+import { map, find } from 'lodash';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import { searchParamsVar } from '../apollo/searchVar';

--- a/views/SearchView.tsx
+++ b/views/SearchView.tsx
@@ -7,7 +7,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { Container, Responsive, Snackbar } from '@zextras/carbonio-design-system';
-import noop from 'lodash/noop';
+import { noop } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { ACTION_IDS, ACTION_TYPES } from '../../constants';

--- a/views/UploadView.test.tsx
+++ b/views/UploadView.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 
 import { screen, waitFor } from '@testing-library/react';
-import keyBy from 'lodash/keyBy';
+import { keyBy } from 'lodash';
 
 import { CreateOptionsContent } from '../../hooks/useCreateOptions';
 import { uploadVar } from '../apollo/uploadVar';

--- a/views/UploadView.tsx
+++ b/views/UploadView.tsx
@@ -7,7 +7,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { Container, Responsive, Snackbar } from '@zextras/carbonio-design-system';
-import noop from 'lodash/noop';
+import { noop } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { ACTION_IDS, ACTION_TYPES } from '../../constants';

--- a/views/components/AdvancedSearchButtonHeader.tsx
+++ b/views/components/AdvancedSearchButtonHeader.tsx
@@ -7,9 +7,7 @@
 import React, { useMemo } from 'react';
 
 import { Button, Container, Divider } from '@zextras/carbonio-design-system';
-import filter from 'lodash/filter';
-import isArray from 'lodash/isArray';
-import isEmpty from 'lodash/isEmpty';
+import { isEmpty, filter, isArray } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { useSearch } from '../../../hooks/useSearch';

--- a/views/components/AdvancedSearchModalContent.tsx
+++ b/views/components/AdvancedSearchModalContent.tsx
@@ -18,11 +18,7 @@ import {
 	ModalHeader,
 	Row
 } from '@zextras/carbonio-design-system';
-import every from 'lodash/every';
-import isArray from 'lodash/isArray';
-import isEmpty from 'lodash/isEmpty';
-import isEqual from 'lodash/isEqual';
-import map from 'lodash/map';
+import { isEmpty, map, isEqual, every, isArray } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 

--- a/views/components/CollaboratorsRow.tsx
+++ b/views/components/CollaboratorsRow.tsx
@@ -6,7 +6,7 @@
 import React, { useCallback, useMemo } from 'react';
 
 import { Avatar, Row, Shimmer, Text, Tooltip } from '@zextras/carbonio-design-system';
-import reduce from 'lodash/reduce';
+import { reduce } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 

--- a/views/components/CopyNodesModalContent.test.tsx
+++ b/views/components/CopyNodesModalContent.test.tsx
@@ -9,8 +9,7 @@
 import React from 'react';
 
 import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { forEach, map } from 'lodash';
 
 import { destinationVar } from '../../apollo/destinationVar';
 import { NODES_LOAD_LIMIT, ROOTS } from '../../constants';

--- a/views/components/CopyNodesModalContent.tsx
+++ b/views/components/CopyNodesModalContent.tsx
@@ -15,9 +15,7 @@ import {
 	Text,
 	TextWithTooltip
 } from '@zextras/carbonio-design-system';
-import every from 'lodash/every';
-import find from 'lodash/find';
-import reduce from 'lodash/reduce';
+import { find, reduce, every } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { DestinationVar, destinationVar } from '../../apollo/destinationVar';

--- a/views/components/DisplayerActions.tsx
+++ b/views/components/DisplayerActions.tsx
@@ -8,7 +8,7 @@ import React, { useCallback, useContext, useMemo } from 'react';
 
 import { Action as DSAction, CollapsingActions, Container } from '@zextras/carbonio-design-system';
 import { PreviewsManagerContext } from '@zextras/carbonio-ui-preview';
-import includes from 'lodash/includes';
+import { includes } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveNode } from '../../../hooks/useActiveNode';

--- a/views/components/DisplayerNode.tsx
+++ b/views/components/DisplayerNode.tsx
@@ -6,8 +6,7 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 
 import { Container, Divider, TabBar, TabBarProps } from '@zextras/carbonio-design-system';
-import filter from 'lodash/filter';
-import map from 'lodash/map';
+import { map, filter } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveNode } from '../../../hooks/useActiveNode';

--- a/views/components/DisplayerPreview.tsx
+++ b/views/components/DisplayerPreview.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } 
 
 import { Button, Container, Icon, Text } from '@zextras/carbonio-design-system';
 import { PreviewsManagerContext } from '@zextras/carbonio-ui-preview';
-import debounce from 'lodash/debounce';
+import { debounce } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 

--- a/views/components/Dropzone.tsx
+++ b/views/components/Dropzone.tsx
@@ -7,8 +7,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Container } from '@zextras/carbonio-design-system';
-import { throttle } from 'lodash';
-import intersection from 'lodash/intersection';
+import { throttle, intersection } from 'lodash';
 import styled, { DefaultTheme } from 'styled-components';
 
 import { TIMERS } from '../../constants';

--- a/views/components/DropzoneModal.tsx
+++ b/views/components/DropzoneModal.tsx
@@ -7,7 +7,7 @@
 import React, { useMemo } from 'react';
 
 import { Container, Icon, Padding, Text } from '@zextras/carbonio-design-system';
-import map from 'lodash/map';
+import { map } from 'lodash';
 import styled, { css, FlattenSimpleInterpolation, SimpleInterpolation } from 'styled-components';
 
 import { cssCalcBuilder } from '../../utils/utils';

--- a/views/components/EmptyDisplayer.tsx
+++ b/views/components/EmptyDisplayer.tsx
@@ -6,9 +6,7 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 
 import { Container, Icon, Padding, Row } from '@zextras/carbonio-design-system';
-import { sample } from 'lodash';
-import debounce from 'lodash/debounce';
-import map from 'lodash/map';
+import { sample, map, debounce } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 

--- a/views/components/EmptySpaceFiller.tsx
+++ b/views/components/EmptySpaceFiller.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { Container } from '@zextras/carbonio-design-system';
-import noop from 'lodash/noop';
+import { noop } from 'lodash';
 
 import { ContextualMenu, ContextualMenuProps } from './ContextualMenu';
 

--- a/views/components/FolderSelectionModalContent.test.tsx
+++ b/views/components/FolderSelectionModalContent.test.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 
 import { screen, waitFor } from '@testing-library/react';
 import 'jest-styled-components';
-import map from 'lodash/map';
+import { map } from 'lodash';
 import { find as findStyled } from 'styled-components/test-utils';
 
 import { destinationVar } from '../../apollo/destinationVar';

--- a/views/components/FolderSelectionModalContent.tsx
+++ b/views/components/FolderSelectionModalContent.tsx
@@ -15,8 +15,7 @@ import {
 	Row,
 	Text
 } from '@zextras/carbonio-design-system';
-import noop from 'lodash/noop';
-import reduce from 'lodash/reduce';
+import { reduce, noop } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { destinationVar, DestinationVar } from '../../apollo/destinationVar';

--- a/views/components/HeaderBreadcrumbs.test.tsx
+++ b/views/components/HeaderBreadcrumbs.test.tsx
@@ -15,9 +15,7 @@ import {
 	waitForElementToBeRemoved,
 	within
 } from '@testing-library/react';
-import find from 'lodash/find';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { forEach, map, find } from 'lodash';
 
 import { UseNavigationHook } from '../../../hooks/useNavigation';
 import { draggedItemsVar } from '../../apollo/dragAndDropVar';

--- a/views/components/ItemTypeChipInput.tsx
+++ b/views/components/ItemTypeChipInput.tsx
@@ -7,8 +7,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { ChipInput, ChipInputProps, ChipItem } from '@zextras/carbonio-design-system';
-import isEmpty from 'lodash/isEmpty';
-import reduce from 'lodash/reduce';
+import { isEmpty, reduce } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { AdvancedFilters } from '../../types/common';

--- a/views/components/List.contextualMenuActions.test.tsx
+++ b/views/components/List.contextualMenuActions.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 
 import { act, fireEvent, screen } from '@testing-library/react';
-import forEach from 'lodash/forEach';
+import { forEach } from 'lodash';
 
 import { ACTION_REGEXP } from '../../constants/test';
 import { populateFolder, populateNode } from '../../mocks/mockUtils';

--- a/views/components/List.markForDeletion.test.tsx
+++ b/views/components/List.markForDeletion.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 
 import { fireEvent, screen, within } from '@testing-library/react';
-import map from 'lodash/map';
+import { map } from 'lodash';
 
 import { ACTION_REGEXP } from '../../constants/test';
 import { populateFile, populateFolder, populateNode } from '../../mocks/mockUtils';

--- a/views/components/List.rename.test.tsx
+++ b/views/components/List.rename.test.tsx
@@ -7,8 +7,7 @@ import React from 'react';
 
 import { ApolloError } from '@apollo/client';
 import { fireEvent, screen, within } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { forEach, map } from 'lodash';
 
 import { ACTION_REGEXP, ICON_REGEXP, SELECTORS } from '../../constants/test';
 import { populateFolder, populateNode, sortNodes } from '../../mocks/mockUtils';

--- a/views/components/List.tsx
+++ b/views/components/List.tsx
@@ -10,13 +10,7 @@ import { useReactiveVar } from '@apollo/client';
 import { Action as DSAction, Container, useSnackbar } from '@zextras/carbonio-design-system';
 import { PreviewsManagerContext } from '@zextras/carbonio-ui-preview';
 import { PreviewManagerContextType } from '@zextras/carbonio-ui-preview/lib/preview/PreviewManager';
-import filter from 'lodash/filter';
-import find from 'lodash/find';
-import includes from 'lodash/includes';
-import isEmpty from 'lodash/isEmpty';
-import reduce from 'lodash/reduce';
-import size from 'lodash/size';
-import some from 'lodash/some';
+import { isEmpty, find, filter, includes, reduce, size, some } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 

--- a/views/components/ListContent.tsx
+++ b/views/components/ListContent.tsx
@@ -7,10 +7,7 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import type { Action as DSAction } from '@zextras/carbonio-design-system';
-import filter from 'lodash/filter';
-import forEach from 'lodash/forEach';
-import includes from 'lodash/includes';
-import map from 'lodash/map';
+import { forEach, map, filter, includes } from 'lodash';
 import styled from 'styled-components';
 
 import useUserInfo from '../../../hooks/useUserInfo';

--- a/views/components/ModalList.tsx
+++ b/views/components/ModalList.tsx
@@ -8,7 +8,7 @@ import React, { useLayoutEffect, useMemo, useRef } from 'react';
 
 import { useQuery } from '@apollo/client';
 import { Container, Row } from '@zextras/carbonio-design-system';
-import takeRightWhile from 'lodash/takeRightWhile';
+import { takeRightWhile } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 

--- a/views/components/ModalRootsList.tsx
+++ b/views/components/ModalRootsList.tsx
@@ -7,9 +7,7 @@
 import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { Container, Row } from '@zextras/carbonio-design-system';
-import forEach from 'lodash/forEach';
-import isEmpty from 'lodash/isEmpty';
-import reduce from 'lodash/reduce';
+import { forEach, isEmpty, reduce } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 

--- a/views/components/MoveNodesModalContent.test.tsx
+++ b/views/components/MoveNodesModalContent.test.tsx
@@ -9,8 +9,7 @@
 import React from 'react';
 
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { forEach, map } from 'lodash';
 
 import { destinationVar } from '../../apollo/destinationVar';
 import { NODES_LOAD_LIMIT } from '../../constants';

--- a/views/components/MoveNodesModalContent.tsx
+++ b/views/components/MoveNodesModalContent.tsx
@@ -14,8 +14,7 @@ import {
 	Text,
 	TextWithTooltip
 } from '@zextras/carbonio-design-system';
-import find from 'lodash/find';
-import reduce from 'lodash/reduce';
+import { find, reduce } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import useUserInfo from '../../../hooks/useUserInfo';

--- a/views/components/NodeDetails.test.tsx
+++ b/views/components/NodeDetails.test.tsx
@@ -7,9 +7,7 @@
 import React from 'react';
 
 import { screen } from '@testing-library/react';
-import { sample } from 'lodash';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { sample, forEach, map } from 'lodash';
 
 import { NODES_LOAD_LIMIT } from '../../constants';
 import {

--- a/views/components/NodeDetails.tsx
+++ b/views/components/NodeDetails.tsx
@@ -8,7 +8,7 @@ import React, { useMemo } from 'react';
 
 import { ApolloError } from '@apollo/client';
 import { Container } from '@zextras/carbonio-design-system';
-import map from 'lodash/map';
+import { map } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { NodeDetailsUserRow } from '../../../components/NodeDetailsUserRow';

--- a/views/components/NodeHoverBar.tsx
+++ b/views/components/NodeHoverBar.tsx
@@ -7,7 +7,7 @@
 import React, { useMemo } from 'react';
 
 import { Action as DSAction, CollapsingActions } from '@zextras/carbonio-design-system';
-import map from 'lodash/map';
+import { map } from 'lodash';
 
 import { HoverBarContainer } from './StyledComponents';
 

--- a/views/components/NodeListItem.tsx
+++ b/views/components/NodeListItem.tsx
@@ -16,9 +16,7 @@ import {
 	useSnackbar
 } from '@zextras/carbonio-design-system';
 import { PreviewsManagerContext } from '@zextras/carbonio-ui-preview';
-import debounce from 'lodash/debounce';
-import includes from 'lodash/includes';
-import some from 'lodash/some';
+import { includes, some, debounce } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';

--- a/views/components/NodeListItemWrapper.tsx
+++ b/views/components/NodeListItemWrapper.tsx
@@ -8,8 +8,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useReactiveVar } from '@apollo/client';
 import { Action as DSAction, useSnackbar } from '@zextras/carbonio-design-system';
-import isEmpty from 'lodash/isEmpty';
-import some from 'lodash/some';
+import { isEmpty, some } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 

--- a/views/components/NodesSelectionModalContent.test.tsx
+++ b/views/components/NodesSelectionModalContent.test.tsx
@@ -11,8 +11,7 @@ import React from 'react';
 import 'jest-styled-components';
 import { ApolloError, ReactiveVar } from '@apollo/client';
 import { act, screen, waitFor, within } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import size from 'lodash/size';
+import { forEach, size } from 'lodash';
 import { find as findStyled } from 'styled-components/test-utils';
 
 import { DestinationVar, destinationVar } from '../../apollo/destinationVar';

--- a/views/components/NodesSelectionModalContent.tsx
+++ b/views/components/NodesSelectionModalContent.tsx
@@ -19,12 +19,7 @@ import {
 	Text,
 	Tooltip
 } from '@zextras/carbonio-design-system';
-import debounce from 'lodash/debounce';
-import findIndex from 'lodash/findIndex';
-import map from 'lodash/map';
-import reduce from 'lodash/reduce';
-import some from 'lodash/some';
-import trim from 'lodash/trim';
+import { map, reduce, some, debounce, findIndex, trim } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { DestinationVar, destinationVar } from '../../apollo/destinationVar';

--- a/views/components/OwnerChipInput.tsx
+++ b/views/components/OwnerChipInput.tsx
@@ -7,10 +7,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { ChipInput, ChipInputProps, ChipItem } from '@zextras/carbonio-design-system';
-import filter from 'lodash/filter';
-import isEmpty from 'lodash/isEmpty';
-import reduce from 'lodash/reduce';
-import throttle from 'lodash/throttle';
+import { isEmpty, filter, reduce, throttle } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { soapFetch } from '../../../network/network';

--- a/views/components/PreventDefaultDropContainer.tsx
+++ b/views/components/PreventDefaultDropContainer.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { Container } from '@zextras/carbonio-design-system';
-import intersection from 'lodash/intersection';
+import { intersection } from 'lodash';
 
 import { DRAG_TYPES } from '../../constants';
 

--- a/views/components/RouteLeavingGuard.tsx
+++ b/views/components/RouteLeavingGuard.tsx
@@ -8,7 +8,7 @@ import React, { useEffect, useState, FC, useMemo } from 'react';
 
 import { Modal, Button } from '@zextras/carbonio-design-system';
 import { Location } from 'history';
-import filter from 'lodash/filter';
+import { filter } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Prompt, useHistory } from 'react-router-dom';
 

--- a/views/components/SearchList.test.tsx
+++ b/views/components/SearchList.test.tsx
@@ -14,8 +14,7 @@ import {
 	waitForElementToBeRemoved,
 	within
 } from '@testing-library/react';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
+import { forEach, map } from 'lodash';
 import { graphql } from 'msw';
 
 import server from '../../../mocks/server';

--- a/views/components/SearchList.tsx
+++ b/views/components/SearchList.tsx
@@ -7,11 +7,7 @@
 import React, { useContext, useEffect, useMemo } from 'react';
 
 import { useReactiveVar } from '@apollo/client';
-import { sample } from 'lodash';
-import filter from 'lodash/filter';
-import isArray from 'lodash/isArray';
-import isEmpty from 'lodash/isEmpty';
-import reduce from 'lodash/reduce';
+import { sample, isEmpty, filter, reduce, isArray } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { useSearch } from '../../../hooks/useSearch';

--- a/views/components/SecondaryBarItem.tsx
+++ b/views/components/SecondaryBarItem.tsx
@@ -15,11 +15,7 @@ import {
 	Row,
 	Tooltip
 } from '@zextras/carbonio-design-system';
-import every from 'lodash/every';
-import find from 'lodash/find';
-import map from 'lodash/map';
-import noop from 'lodash/noop';
-import uniq from 'lodash/uniq';
+import { map, uniq, find, noop, every } from 'lodash';
 import styled from 'styled-components';
 
 import useUserInfo from '../../../hooks/useUserInfo';

--- a/views/components/UpdateNodeNameModalContent.tsx
+++ b/views/components/UpdateNodeNameModalContent.tsx
@@ -15,7 +15,7 @@ import {
 	ModalFooter,
 	ModalHeader
 } from '@zextras/carbonio-design-system';
-import trim from 'lodash/trim';
+import { trim } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { CreateDocsFile } from '../../types/common';

--- a/views/components/UploadDisplayerNode.test.tsx
+++ b/views/components/UploadDisplayerNode.test.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import { faker } from '@faker-js/faker';
 import { screen } from '@testing-library/react';
-import keyBy from 'lodash/keyBy';
+import { keyBy } from 'lodash';
 
 import { uploadVar } from '../../apollo/uploadVar';
 import { ICON_REGEXP } from '../../constants/test';

--- a/views/components/UploadDisplayerNode.tsx
+++ b/views/components/UploadDisplayerNode.tsx
@@ -6,9 +6,7 @@
 import React, { useMemo } from 'react';
 
 import { CollapsingActions, Container } from '@zextras/carbonio-design-system';
-import drop from 'lodash/drop';
-import isEqual from 'lodash/isEqual';
-import map from 'lodash/map';
+import { map, isEqual, drop } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveNode } from '../../../hooks/useActiveNode';

--- a/views/components/UploadList.goToFolder.test.tsx
+++ b/views/components/UploadList.goToFolder.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 
 import { screen } from '@testing-library/react';
-import keyBy from 'lodash/keyBy';
+import { keyBy } from 'lodash';
 import { useLocation } from 'react-router-dom';
 
 import { uploadVar } from '../../apollo/uploadVar';

--- a/views/components/UploadList.remove.test.tsx
+++ b/views/components/UploadList.remove.test.tsx
@@ -9,8 +9,7 @@ import { ApolloError } from '@apollo/client';
 import { faker } from '@faker-js/faker';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { EventEmitter } from 'events';
-import forEach from 'lodash/forEach';
-import keyBy from 'lodash/keyBy';
+import { forEach, keyBy } from 'lodash';
 import { graphql, ResponseResolver, rest, RestContext, RestRequest } from 'msw';
 
 import server from '../../../mocks/server';

--- a/views/components/UploadList.retry.test.tsx
+++ b/views/components/UploadList.retry.test.tsx
@@ -10,8 +10,7 @@ import { ApolloError } from '@apollo/client';
 import { faker } from '@faker-js/faker';
 import { screen, waitFor } from '@testing-library/react';
 import { EventEmitter } from 'events';
-import forEach from 'lodash/forEach';
-import keyBy from 'lodash/keyBy';
+import { forEach, keyBy } from 'lodash';
 import { graphql, rest } from 'msw';
 
 import server from '../../../mocks/server';

--- a/views/components/UploadList.test.tsx
+++ b/views/components/UploadList.test.tsx
@@ -16,8 +16,7 @@ import {
 	within
 } from '@testing-library/react';
 import { EventEmitter } from 'events';
-import find from 'lodash/find';
-import forEach from 'lodash/forEach';
+import { forEach, find } from 'lodash';
 import { rest } from 'msw';
 
 import server from '../../../mocks/server';

--- a/views/components/UploadList.tsx
+++ b/views/components/UploadList.tsx
@@ -8,10 +8,7 @@ import React, { useCallback, useContext, useEffect, useMemo } from 'react';
 
 import { useQuery } from '@apollo/client';
 import { Button, Container, useSnackbar } from '@zextras/carbonio-design-system';
-import filter from 'lodash/filter';
-import includes from 'lodash/includes';
-import map from 'lodash/map';
-import size from 'lodash/size';
+import { map, filter, includes, size } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import ListHeader from '../../../components/ListHeader';

--- a/views/components/UploadNodeDetailsListItem.tsx
+++ b/views/components/UploadNodeDetailsListItem.tsx
@@ -8,7 +8,7 @@ import React, { useMemo } from 'react';
 
 import { useQuery } from '@apollo/client';
 import { Container, Text } from '@zextras/carbonio-design-system';
-import reduce from 'lodash/reduce';
+import { reduce } from 'lodash';
 
 import { LIST_ITEM_AVATAR_HEIGHT_COMPACT } from '../../constants';
 import { Breadcrumbs } from '../../design_system_fork/Breadcrumbs';

--- a/views/components/sharing/AddShareChip.tsx
+++ b/views/components/sharing/AddShareChip.tsx
@@ -8,8 +8,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { ChipAction } from '@zextras/carbonio-design-system';
-import filter from 'lodash/filter';
-import toLower from 'lodash/toLower';
+import { filter, toLower } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveNode } from '../../../../hooks/useActiveNode';

--- a/views/components/sharing/AddSharing.contactGroup.test.tsx
+++ b/views/components/sharing/AddSharing.contactGroup.test.tsx
@@ -6,10 +6,7 @@
 import React from 'react';
 
 import { screen, waitFor, within } from '@testing-library/react';
-import find from 'lodash/find';
-import forEach from 'lodash/forEach';
-import map from 'lodash/map';
-import reduce from 'lodash/reduce';
+import { forEach, map, find, reduce } from 'lodash';
 
 import { soapFetch } from '../../../../network/network';
 import {

--- a/views/components/sharing/AddSharing.tsx
+++ b/views/components/sharing/AddSharing.tsx
@@ -14,18 +14,20 @@ import {
 	Container,
 	Text
 } from '@zextras/carbonio-design-system';
-import filter from 'lodash/filter';
-import findIndex from 'lodash/findIndex';
-import first from 'lodash/first';
-import forEach from 'lodash/forEach';
-import keyBy from 'lodash/keyBy';
-import map from 'lodash/map';
-import reduce from 'lodash/reduce';
-import size from 'lodash/size';
-import some from 'lodash/some';
-import throttle from 'lodash/throttle';
-import trim from 'lodash/trim';
-import uniq from 'lodash/uniq';
+import {
+	forEach,
+	map,
+	uniq,
+	filter,
+	reduce,
+	size,
+	some,
+	findIndex,
+	first,
+	trim,
+	keyBy,
+	throttle
+} from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { soapFetch } from '../../../../network/network';

--- a/views/components/sharing/EditShareChip.tsx
+++ b/views/components/sharing/EditShareChip.tsx
@@ -8,8 +8,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 
 import { FetchResult, useLazyQuery } from '@apollo/client';
 import { ChipAction, Text, useSnackbar } from '@zextras/carbonio-design-system';
-import filter from 'lodash/filter';
-import map from 'lodash/map';
+import { map, filter } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { SHARE_CHIP_MAX_WIDTH, SHARE_CHIP_SIZE } from '../../../constants';

--- a/views/components/sharing/EditShareChipPopoverContainer.tsx
+++ b/views/components/sharing/EditShareChipPopoverContainer.tsx
@@ -16,8 +16,7 @@ import {
 	Button,
 	pseudoClasses
 } from '@zextras/carbonio-design-system';
-import includes from 'lodash/includes';
-import noop from 'lodash/noop';
+import { includes, noop } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import styled, { SimpleInterpolation } from 'styled-components';
 

--- a/views/components/sharing/NewShareChipPopoverContainer.tsx
+++ b/views/components/sharing/NewShareChipPopoverContainer.tsx
@@ -15,7 +15,7 @@ import {
 	Checkbox,
 	pseudoClasses
 } from '@zextras/carbonio-design-system';
-import includes from 'lodash/includes';
+import { includes } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import styled, { SimpleInterpolation } from 'styled-components';
 

--- a/views/components/sharing/NodeSharing.test.tsx
+++ b/views/components/sharing/NodeSharing.test.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { act, screen, waitFor, within } from '@testing-library/react';
-import forEach from 'lodash/forEach';
+import { forEach } from 'lodash';
 
 import { SELECTORS } from '../../../constants/test';
 import {

--- a/views/components/sharing/NodeSharing.tsx
+++ b/views/components/sharing/NodeSharing.tsx
@@ -16,7 +16,7 @@ import {
 	Text,
 	Tooltip
 } from '@zextras/carbonio-design-system';
-import reduce from 'lodash/reduce';
+import { reduce } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 

--- a/views/components/sharing/collaborationLinks/CollaborationLinks.tsx
+++ b/views/components/sharing/collaborationLinks/CollaborationLinks.tsx
@@ -19,7 +19,7 @@ import {
 	useModal,
 	useSnackbar
 } from '@zextras/carbonio-design-system';
-import find from 'lodash/find';
+import { find } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { useCreateCollaborationLinkMutation } from '../../../../hooks/graphql/mutations/useCreateCollaborationLinkMutation';

--- a/views/components/sharing/publicLink/PublicLink.tsx
+++ b/views/components/sharing/publicLink/PublicLink.tsx
@@ -15,8 +15,7 @@ import {
 	useModal,
 	useSnackbar
 } from '@zextras/carbonio-design-system';
-import reduce from 'lodash/reduce';
-import size from 'lodash/size';
+import { reduce, size } from 'lodash';
 import moment from 'moment-timezone';
 import { useTranslation } from 'react-i18next';
 

--- a/views/components/sharing/publicLink/PublicLinkComponent.tsx
+++ b/views/components/sharing/publicLink/PublicLinkComponent.tsx
@@ -19,7 +19,7 @@ import {
 	Row,
 	useSnackbar
 } from '@zextras/carbonio-design-system';
-import size from 'lodash/size';
+import { size } from 'lodash';
 import moment from 'moment-timezone';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';

--- a/views/components/versioning/GridElements.tsx
+++ b/views/components/versioning/GridElements.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Container } from '@zextras/carbonio-design-system';
-import reduce from 'lodash/reduce';
+import { reduce } from 'lodash';
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
 
 export const GridItem = styled(Container)<{

--- a/views/components/versioning/VersionRow.tsx
+++ b/views/components/versioning/VersionRow.tsx
@@ -15,7 +15,7 @@ import {
 	Container,
 	useSnackbar
 } from '@zextras/carbonio-design-system';
-import forEach from 'lodash/forEach';
+import { forEach } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 

--- a/views/components/versioning/Versioning.test.tsx
+++ b/views/components/versioning/Versioning.test.tsx
@@ -6,8 +6,7 @@
 import React from 'react';
 
 import { screen, waitFor, within } from '@testing-library/react';
-import find from 'lodash/find';
-import map from 'lodash/map';
+import { map, find } from 'lodash';
 import { graphql, rest } from 'msw';
 
 import server from '../../../../mocks/server';

--- a/views/components/versioning/Versioning.tsx
+++ b/views/components/versioning/Versioning.tsx
@@ -8,12 +8,7 @@ import React, { useCallback, useMemo } from 'react';
 
 import { FetchResult } from '@apollo/client';
 import { Button, Container, Padding, Text } from '@zextras/carbonio-design-system';
-import drop from 'lodash/drop';
-import filter from 'lodash/filter';
-import keyBy from 'lodash/keyBy';
-import map from 'lodash/map';
-import partition from 'lodash/partition';
-import take from 'lodash/take';
+import { map, filter, partition, take, keyBy, drop } from 'lodash';
 import moment from 'moment-timezone';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';


### PR DESCRIPTION
Refactor the way imports from lodash are made in order to take advantage of the sdk build, which treats lodash import as external. In this way, the bundle of Files is reduced because it does not include lodash anymore.

refs: FILES-568